### PR TITLE
[PLAT-11345] Add support for set token content-type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    oneroster (2.3.6)
+    oneroster (2.3.9)
       dry-inflector
       faraday
       faraday_middleware

--- a/lib/one_roster/client.rb
+++ b/lib/one_roster/client.rb
@@ -4,7 +4,7 @@ module OneRoster
   class Client
     attr_accessor :app_id, :app_token, :api_url, :token_url, :roster_app,
                   :app_secret, :logger, :vendor_key,
-                  :username_source, :oauth_strategy, :staff_username_source
+                  :username_source, :oauth_strategy, :staff_username_source, :token_content_type
 
     attr_reader :authenticated
 
@@ -134,9 +134,9 @@ module OneRoster
                             scope: 'https://purl.imsglobal.org/spec/or/v1p1/scope/roster-core.readonly' }
 
       if roster_app == 'infinite_campus'
-        connection.execute(url, :post, credential_params)
+        connection.execute(url, :post, credential_params, nil, token_content_type)
       elsif roster_app == 'synergy'
-        connection.execute(url, :post, nil, credential_params)
+        connection.execute(url, :post, nil, credential_params, token_content_type)
       else
         connection.execute(url, :post)
       end

--- a/lib/one_roster/connection.rb
+++ b/lib/one_roster/connection.rb
@@ -10,8 +10,8 @@ module OneRoster
       @oauth_strategy = oauth_strategy
     end
 
-    def execute(path, method = :get, params = nil, body = nil)
-      Response.new(raw_request(path, method, params, body))
+    def execute(path, method = :get, params = nil, body = nil, content_type = nil)
+      Response.new(raw_request(path, method, params, body, content_type))
     end
 
     def set_auth_headers(token, cookie)
@@ -37,29 +37,35 @@ module OneRoster
 
     private
 
-    def raw_request(path, method, params, body)
+    def raw_request(path, method, params, body, content_type = nil)
       p "request #{path} #{params}"
 
       connection.public_send(method) do |request|
         request.options.open_timeout     = OPEN_TIMEOUT
         request.options.timeout          = TIMEOUT
         request.url path, params
-        request.headers['Content-Type']  = content_type
+        request.headers['Content-Type']  = content_type || set_content_type
         request.headers['Cookie']        = @cookie
-        request.body                     = render_body(body)
+        request.body                     = render_body(body, content_type)
       end
     end
 
-    def content_type
+    def set_content_type
       return 'application/x-www-form-urlencoded' if @client.roster_app == 'synergy'
 
       'application/json'
     end
 
-    def render_body(body)
-      return URI.encode_www_form(body) if !body.nil? && @client.roster_app == 'synergy'
+    def render_body(body, content_type)
+      return URI.encode_www_form(body) if should_encode_body?(body, content_type)
 
       body
+    end
+
+    def should_encode_body?(body, content_type)
+      return false if body.nil?
+
+      @client.roster_app == 'synergy' || content_type == 'application/x-www-form-urlencoded'
     end
 
     def oauth_connection

--- a/lib/one_roster/version.rb
+++ b/lib/one_roster/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OneRoster
-  VERSION = '2.3.6'
+  VERSION = '2.3.9'
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -518,7 +518,55 @@ RSpec.describe OneRoster::Client do
         client.connection.expects(:execute)
               .with(token_url, :post,
                     { grant_type: 'client_credentials',
-                      scope: 'https://purl.imsglobal.org/spec/or/v1p1/scope/roster-core.readonly' })
+                      scope: 'https://purl.imsglobal.org/spec/or/v1p1/scope/roster-core.readonly' }, nil, nil)
+        client.token
+      end
+    end
+
+    context 'when the app is synergy' do
+      let(:client) do
+        OneRoster::Client.configure do |config|
+          config.app_id                = app_id
+          config.app_secret            = app_secret
+          config.api_url               = api_url
+          config.username_source       = username_source
+          config.staff_username_source = staff_username_source
+          config.token_url             = token_url
+          config.roster_app            = 'synergy'
+        end
+      end
+
+      it 'requests with the grant_type' do
+        client.connection.expects(:execute)
+              .with(token_url, :post,
+                    nil,
+                    { grant_type: 'client_credentials',
+                      scope: 'https://purl.imsglobal.org/spec/or/v1p1/scope/roster-core.readonly' },
+                    nil)
+        client.token
+      end
+    end
+
+    context 'when a content type is defined' do
+      let(:content_type) { 'application/json' }
+      let(:client) do
+        OneRoster::Client.configure do |config|
+          config.app_id                = app_id
+          config.app_secret            = app_secret
+          config.api_url               = api_url
+          config.username_source       = username_source
+          config.staff_username_source = staff_username_source
+          config.token_url             = token_url
+          config.roster_app            = 'infinite_campus'
+          config.token_content_type    = content_type
+        end
+      end
+
+      it 'requests with the grant_type' do
+        client.connection.expects(:execute)
+              .with(token_url, :post,
+                    { grant_type: 'client_credentials',
+                      scope: 'https://purl.imsglobal.org/spec/or/v1p1/scope/roster-core.readonly' }, nil, content_type)
         client.token
       end
     end


### PR DESCRIPTION
https://teachtci2.atlassian.net/browse/PLAT-11345

Infinite Campus released an update that requires tokens to be requested via `application/x-www-form-urlencoded` content-type. Instead of mapping each supported SIS to a content-type, we can be flexible by allowing users to specify their SIS's content-type for token fetching.