### PR TITLE
[PLAT-14275] One Roster raise error to enter sidekiq retry

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    oneroster (2.3.21)
+    oneroster (2.3.22)
       dry-inflector (~> 1.0.0)
       faraday
       faraday_middleware
@@ -17,7 +17,7 @@ GEM
     diff-lcs (1.3)
     docile (1.4.1)
     dry-inflector (1.0.0)
-    faraday (1.10.3)
+    faraday (1.10.4)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -33,14 +33,14 @@ GEM
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
-    faraday-net_http (1.0.1)
+    faraday-multipart (1.1.0)
+      multipart-post (~> 2.0)
+    faraday-net_http (1.0.2)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
-    faraday_middleware (1.2.0)
+    faraday_middleware (1.2.1)
       faraday (~> 1.0)
     hashie (5.0.0)
     json (2.9.1)
@@ -49,7 +49,7 @@ GEM
     method_source (0.8.2)
     mocha (1.8.0)
       metaclass (~> 0.0.1)
-    multipart-post (2.3.0)
+    multipart-post (2.4.1)
     oauth (1.1.0)
       oauth-tty (~> 1.0, >= 1.0.1)
       snaky_hash (~> 2.0)
@@ -114,7 +114,7 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
-    version_gem (1.1.3)
+    version_gem (1.1.6)
 
 PLATFORMS
   ruby

--- a/lib/one_roster/connection.rb
+++ b/lib/one_roster/connection.rb
@@ -24,7 +24,7 @@ module OneRoster
           'response.http_status' => response.status,
           'response.raw_body' => response.raw_body
         )
-        raise GatewayTimeoutError if response.status == 504
+        raise GatewayTimeoutError if response.timed_out?
       end
 
       response

--- a/lib/one_roster/connection.rb
+++ b/lib/one_roster/connection.rb
@@ -24,6 +24,7 @@ module OneRoster
           'response.http_status' => response.status,
           'response.raw_body' => response.raw_body
         )
+        raise if response.status == 504
       end
 
       response

--- a/lib/one_roster/connection.rb
+++ b/lib/one_roster/connection.rb
@@ -24,7 +24,7 @@ module OneRoster
           'response.http_status' => response.status,
           'response.raw_body' => response.raw_body
         )
-        raise if response.status == 504
+        raise GatewayTimeoutError if response.status == 504
       end
 
       response
@@ -114,5 +114,7 @@ module OneRoster
         **{ extra: payload }
       )
     end
+
+    class GatewayTimeoutError < StandardError; end
   end
 end

--- a/lib/one_roster/response.rb
+++ b/lib/one_roster/response.rb
@@ -24,6 +24,10 @@ module OneRoster
       @status == 200
     end
 
+    def timed_out?
+      @status == 504
+    end
+
     private
 
     def resource_type(faraday_response)

--- a/lib/one_roster/version.rb
+++ b/lib/one_roster/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OneRoster
-  VERSION = '2.3.21'
+  VERSION = '2.3.22'
 end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -97,6 +97,7 @@ RSpec.describe OneRoster::Connection do
 
     context '504 response' do
       subject { connection.execute('/teachers', :get, limit: OneRoster::PAGE_LIMIT) }
+
       let(:status) { 504 }
       let(:body) { 'Gateway Timeout' }
 

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -94,6 +94,28 @@ RSpec.describe OneRoster::Connection do
         end
       end
     end
+
+    context '504 response' do
+      subject { connection.execute('/teachers', :get, limit: OneRoster::PAGE_LIMIT) }
+      let(:status) { 504 }
+      let(:body) { 'Gateway Timeout' }
+
+      before { connection.stubs(:raw_request).returns(mock_response) }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(OneRoster::Connection::GatewayTimeoutError)
+      end
+
+      context 'with a sentry_client configured' do
+        let(:sentry_client) { stub(capture_message: stub) }
+
+        it 'logs to sentry and raises' do
+          sentry_client.expects(:capture_message)
+
+          expect { subject }.to raise_error(OneRoster::Connection::GatewayTimeoutError)
+        end
+      end
+    end
   end
 
   describe '#log' do


### PR DESCRIPTION
PLAT-14275
This PR explicitly raises an error if the response status is a 504, which will force the sidekiq job into retries.